### PR TITLE
Space separated perfdata

### DIFF
--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -432,8 +432,8 @@ if ($response->is_success) {
                  ,$MaxActiveProcesses,$MaxChildrenReachedNew
                  ,$ReqPerSec,$ListenQueue,$ListenQueueLen,$MaxListenQueueNew);
 
-    $PerfData = sprintf ("Idle=%d;Busy=%d;MaxProcesses=%d;MaxProcessesReach=%d;"
-                 ."Queue=%d;MaxQueueReach=%d;QueueLen=%d;ReqPerSec=%f"
+    $PerfData = sprintf ("Idle=%d Busy=%d MaxProcesses=%d MaxProcessesReach=%d "
+                 ."Queue=%d MaxQueueReach=%d QueueLen=%d ReqPerSec=%f"
                  ,($IdleProcesses),($ActiveProcesses),($MaxActiveProcesses)
                  ,($MaxChildrenReachedNew),($ListenQueue),($MaxListenQueueNew)
                  ,($ListenQueueLen),$ReqPerSec);


### PR DESCRIPTION
Had problems getting perfdata from check_phpfpm_status to influxdb (via graphios). The problem was that graphios looks for a space separated list of label/value pairs (as per specification, see: https://nagios-plugins.org/doc/guidelines.html#AEN200) rather then a ';' separated list.

Not sure if the ';'-separated list was a specific design choice of this plugin but Im guessing that it isn't so here's a pull request that fixes the issue. Feel free to disregard this pull-request if I'm wrong. :)
