### PR TITLE
Added default perl module path for Ubuntu Linux

### DIFF
--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -23,6 +23,7 @@ use Digest::MD5 qw(md5 md5_hex);
 # Nagios specific
 # Update Nagios Plugin path according to your platform/installation
 use lib "/usr/local/nagios/libexec";
+use lib "/usr/lib/nagios/plugins";
 use utils qw($TIMEOUT);
 
 # Globals


### PR DESCRIPTION
Added default perl module path for Ubuntu Linux.
Considering it's popularity, should be useful for many people.