### PR TITLE
Added support for connecting to an UNIX socket

### DIFF
--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -48,6 +48,7 @@ my $o_warn_threshold= undef;     # warning thresholds entry
 my $o_crit_threshold= undef;     # critical thresholds entry
 my $o_debug=          undef;     # debug mode
 my $o_fastcgi=        undef;     # direct fastcgi mode (without an http->fastcgi proxy)
+my $o_unixsocket=     undef;     # use a UNIX socket (in direct fastcgi mode)
 my $o_servername=     undef;     # ServerName (host header in http request)
 my $o_https=          undef;     # SSL (HTTPS) mode
 my $o_verify_ssl=     0;         # SSL verification, False by default

--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -296,13 +296,11 @@ if (defined($o_fastcgi)) {
     # -- FASTCGI
     eval "use FCGI::Client::Connection;";
     nagios_exit($phpfpm,"UNKNOWN","You need to activate FCGI::Client::Connection CPAN module for this feature: " . $@) if $@;
-    eval "use IO::Socket::INET";
-    nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::INET CPAN module for this feature: " . $@) if $@;
-    eval "use IO::Socket::UNIX";
-    nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::UNIX CPAN module for this feature: " . $@) if $@;
 
     my $sock;
     if (defined($o_unixsocket)) {
+        eval "use IO::Socket::UNIX";
+        nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::UNIX CPAN module for this feature: " . $@) if $@;
         $sock = IO::Socket::UNIX->new(
             Type => SOCK_STREAM(),
             Peer => $o_unixsocket,
@@ -311,6 +309,8 @@ if (defined($o_fastcgi)) {
             nagios_exit($phpfpm,"CRITICAL", "Cannot connect to UNIX socket $o_unixsocket !");
         }
     } else {
+        eval "use IO::Socket::INET";
+        nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::INET CPAN module for this feature: " . $@) if $@;
         if (!defined($o_port)) {
             $o_port = 9000;
         }

--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -108,7 +108,7 @@ sub help {
    ServerName, (host header of HTTP request) use it if you specified an IP in -H to match the good Virtualhost in your target
 -f, --fastcgi
    Connect directly to php-fpm via network or local socket, using fastcgi protocol instead of HTTP.
--u, --unixsocket
+--unixsocket
    Connect to php-fpm via UNIX socket, implies --fastcgi
 -U, --user=user
    Username for basic auth
@@ -212,8 +212,8 @@ sub check_options {
       'r:s'   => \$o_realm,         'realm:s'          => \$o_realm,
       'p:i'   => \$o_port,          'port:i'           => \$o_port,
       'V'     => \$o_version,       'version'          => \$o_version,
-      'w=s'   => \$o_warn_threshold, 'warn=s'           => \$o_warn_threshold,
-      'c=s'   => \$o_crit_threshold, 'critical=s'       => \$o_crit_threshold,
+      'w=s'   => \$o_warn_threshold, 'warn=s'          => \$o_warn_threshold,
+      'c=s'   => \$o_crit_threshold, 'critical=s'      => \$o_crit_threshold,
       't:i'   => \$o_timeout,       'timeout:i'        => \$o_timeout,
       'x:i'   => \$o_verify_ssl,    'verifyhostname:i' => \$o_verify_ssl,
                                     'verifyssl:i'      => \$o_verify_ssl,

--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -301,6 +301,9 @@ if (defined($o_fastcgi)) {
     if (defined($o_unixsocket)) {
         eval "use IO::Socket::UNIX;";
         nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::UNIX CPAN module for this feature: " . $@) if $@;
+        if (!-S $o_unixsocket) {
+          nagios_exit($phpfpm,"UNKNOWN","$o_unixsocket is not an UNIX socket");
+        }
         $sock = IO::Socket::UNIX->new(
             Type => SOCK_STREAM(),
             Peer => $o_unixsocket,

--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -299,7 +299,7 @@ if (defined($o_fastcgi)) {
 
     my $sock;
     if (defined($o_unixsocket)) {
-        eval "use IO::Socket::UNIX";
+        eval "use IO::Socket::UNIX;";
         nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::UNIX CPAN module for this feature: " . $@) if $@;
         $sock = IO::Socket::UNIX->new(
             Type => SOCK_STREAM(),
@@ -309,7 +309,7 @@ if (defined($o_fastcgi)) {
             nagios_exit($phpfpm,"CRITICAL", "Cannot connect to UNIX socket $o_unixsocket !");
         }
     } else {
-        eval "use IO::Socket::INET";
+        eval "use IO::Socket::INET;";
         nagios_exit($phpfpm,"UNKNOWN","You need to activate IO::Socket::INET CPAN module for this feature: " . $@) if $@;
         if (!defined($o_port)) {
             $o_port = 9000;


### PR DESCRIPTION
Hi @regilero!

Here's a merge request that adds support for UNIX sockets.
Notes: when --unixsocket is used, -f --fastcgi is implied

```
root@nginx1-ha1:/usr/lib/nagios/plugins# ./check_phpfpm_status.pl -H 127.0.0.1 --fastcgi --unixsocket /run/php/php7.1-fpm.sock -u /fpm-status -w 1,1,1 -c 0,2,2
PHP-FPM OK - www, 0.051 sec. response time, Busy/Idle 1/149, (max: 1, reached: 0), ReqPerSec 0.0, Queue 0 (len: 0, reached: 0)|Idle=149 Busy=1 MaxProcesses=1 MaxProcessesReach=0 Queue=0 MaxQueueReach=0 QueueLen=0 ReqPerSec=0.000000
```