### PR TITLE
changed tempfile naming, added some debugging and fixed a typo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
+version 1.2 Beta (06-2019)
+* changed naming of the temporary file @magenbrot
+* fixed some typos @magenbrot
+
 version 1.1 Beta (12-2016) - current moving version
 * icinga2 configuration sample @BarbUk
 
 version 1.0 (23-12-2016)
-* Add a direct fascgi mode (without using an http proxy), only for tcp/ip sockets, not file sockets.
+* Add a direct fastcgi mode (without using an http proxy), only for tcp/ip sockets, not file sockets.
 * verifyhostname only available for LWP::UserAgent->VERSION >= 6.10 (fix #15)
 * remove utils.pm dependency (so remove also nagios lib paths)
 * rework --ssl, use TLSv1 by default, but you can alter that on the command line,
@@ -28,11 +32,11 @@ version 0.9 Beta
 * Detect text/html response and exit on CRITICAL (not the good response)
 
 Version 0.3
-* warn and critical thresolds now contains 3 values (minimum idle process, max processes reached, max queue reached)
+* warn and critical thresholds now contains 3 values (minimum idle processes, max processes reached, max queue reached)
 * fixed max queue reached
 
 Version 0.2
-* add -s/--servname option, possibility to request by IP with a right Host HTTP header
+* add -s/--servername option, possibility to request by IP with a right HTTP host header
 * add -d/--debug option
 
 Version 0.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Support of http, https and fastgi direct mode.
 
 You can use this script to draw some graphics (perfparse).
 
-PHP-FPM Monitor for Nagios version 1.1
+PHP-FPM Monitor for Nagios version 1.2
 
 GPL licence, (c)2012 Leroy Regis
 

--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # check_phpfpm_status.pl
-# Version : 1.1
+# Version : 1.2
 # Author  : regis.leroy at makina-corpus.com
 #           based on previous apache status work by Dennis D. Spreen (dennis at spreendigital.de)
 #						Based on check_apachestatus.pl v1.4 by
@@ -26,7 +26,7 @@ package main;
 binmode(STDOUT, ":utf8");
 
 # Globals
-my $Version=          '1.1';
+my $Version=          '1.2';
 my $Name=             $0;
 
 my $o_host=           undef;     # hostname
@@ -556,7 +556,7 @@ if ($response->is_success) {
         print ("\nDEBUG Parse results => Pool:" . $Pool . "\nAcceptedConn:" . $AcceptedConn . "\nActiveProcesses:" . $ActiveProcesses . " TotalProcesses :".$TotalProcesses . " IdleProcesses :" .$IdleProcesses . "\nMaxActiveProcesses :" . $MaxActiveProcesses . " MaxChildrenReached :" . $MaxChildrenReached . "\nListenQueue :" . $ListenQueue . " ListenQueueLen : " .$ListenQueueLen . " MaxListenQueue: " . $MaxListenQueue ."\n");
     }
 
-    my $TempFile = $TempPath . 'check_phpfpm_status_' . $Pool . "_" . md5_hex($url);
+    my $TempFile = $TempPath . 'check_phpfpm_status_' . $o_host . '_' . $Pool . "_" . md5_hex($url);
     my $FH;
 
     # Debug

--- a/check_phpfpm_status.pl
+++ b/check_phpfpm_status.pl
@@ -556,33 +556,41 @@ if ($response->is_success) {
         print ("\nDEBUG Parse results => Pool:" . $Pool . "\nAcceptedConn:" . $AcceptedConn . "\nActiveProcesses:" . $ActiveProcesses . " TotalProcesses :".$TotalProcesses . " IdleProcesses :" .$IdleProcesses . "\nMaxActiveProcesses :" . $MaxActiveProcesses . " MaxChildrenReached :" . $MaxChildrenReached . "\nListenQueue :" . $ListenQueue . " ListenQueueLen : " .$ListenQueueLen . " MaxListenQueue: " . $MaxListenQueue ."\n");
     }
 
-    my $TempFile = $TempPath.$o_host.'_check_phpfpm_status'.md5_hex($url);
+    my $TempFile = $TempPath . 'check_phpfpm_status_' . $Pool . "_" . md5_hex($url);
     my $FH;
+
+    # Debug
+    if (defined ($o_debug)) {
+        print ("\nDEBUG temporary data file: " . $TempFile . "\n");
+    }
 
     my $LastUptime = 0;
     my $LastAcceptedConn = 0;
     my $LastMaxChildrenReached = 0;
     my $LastMaxListenQueue = 0;
-    if ((-e $TempFile) && (-r $TempFile) && (-w $TempFile))
-    {
-        open ($FH, '<',$TempFile) or nagios_exit($phpfpm,"UNKNOWN","unable to read temporary data from :".$TempFile);
+    if (-r $TempFile) {
+        open ($FH, '<', $TempFile) or nagios_exit($phpfpm,"UNKNOWN","unable to read temporary data from :".$TempFile);
         $LastUptime = <$FH>;
         $LastAcceptedConn = <$FH>;
         $LastMaxChildrenReached = <$FH>;
         $LastMaxListenQueue = <$FH>;
         close ($FH);
         if (defined ($o_debug)) {
-            print ("\nDebug: data from temporary file:\n");
-            print ("LastUptime: $LastUptime LastAcceptedConn: $LastAcceptedConn LastMaxChildrenReached: $LastMaxChildrenReached LastMaxListenQueue: $LastMaxListenQueue \n");
+            print ("\nDebug: read data from temporary file:\n");
+            print (" LastUptime: $LastUptime LastAcceptedConn: $LastAcceptedConn LastMaxChildrenReached: $LastMaxChildrenReached LastMaxListenQueue: $LastMaxListenQueue\n");
         }
     }
 
-    open ($FH, '>'.$TempFile) or nagios_exit($phpfpm,"UNKNOWN","unable to write temporary data in :".$TempFile);
+    open ($FH, '>', $TempFile) or nagios_exit($phpfpm,"UNKNOWN","unable to write temporary data in :".$TempFile);
     print $FH "$Uptime\n";
     print $FH "$AcceptedConn\n";
     print $FH "$MaxChildrenReached\n";
     print $FH "$MaxListenQueue\n";
     close ($FH);
+    if (defined ($o_debug)) {
+        print ("Debug: wrote data to temporary file:\n");
+        print (" Uptime: $Uptime\n AcceptedConn: $AcceptedConn\n MaxChildrenReached: $MaxChildrenReached\n MaxListenQueue: $MaxListenQueue\n\n");
+    }
 
     my $ReqPerSec = 0;
     my $Accesses = 0;


### PR DESCRIPTION
Hi @regilero,

I've had a problem while using your check. The temporary file was created with the hostname given as argument. This leads to problems when you have more than one PHP-FPM pool, since all data was written to the same file when using multiple checks.

I've changed the $TempFile variable to use the $Pool from the status page result.

Additionally I added some more debugging and fixed a typo.